### PR TITLE
Fix non spec conformant login oauth flow

### DIFF
--- a/github/api/client.py
+++ b/github/api/client.py
@@ -64,8 +64,10 @@ class GitHubClient:
         self.token = token
         self._login_state = ""
 
-    def get_login_url(self, redirect_uri: Union[str, URL], scope: str = "user repo") -> URL:
-        self._login_state = "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
+    def get_login_url(self, user_id: str, scope: str = "user repo") -> URL:
+        user_id = user_id + "%"
+        self._randomState = "".join(random.choices(string.ascii_lowercase + string.digits, k=64))
+        self._login_state = user_id+self._randomState
         return self.login_url.with_query({
             "client_id": self.client_id,
             "redirect_uri": str(redirect_uri),

--- a/github/client_manager.py
+++ b/github/client_manager.py
@@ -107,7 +107,7 @@ class ClientManager:
         except ValueError:
             return web.Response(status=401, text="Invalid state token because of ValueError")
         except (KeyError, ClientError):
-            return web.Response(status=401, text=f"Failed to finish login{ClientError}")
+            return web.Response(status=401, text=f"Failed to finish login")
         resp = await client.query("viewer { login }")
         user = resp["viewer"]["login"]
         self.put(user_id, client.token)

--- a/github/client_manager.py
+++ b/github/client_manager.py
@@ -92,20 +92,22 @@ class ClientManager:
                                                  f"{error_msg}\n\n"
                                                  f"More info at {error_uri}")
         try:
-            user_id = UserID(request.query["user_id"])
+            user_id_raw, randomState = (request.query["state"]).split('%')
+            user_id = UserID(user_id_raw)
             code = request.query["code"]
             state = request.query["state"]
+
         except KeyError as e:
             return web.Response(status=400, text=f"Missing {e.args[0]} parameter")
         client = self.get(user_id)
         if not client:
-            return web.Response(status=401, text="Invalid state token")
+            return web.Response(status=401, text="Invalid state token because no client")
         try:
             await client.finish_login(code, state)
         except ValueError:
-            return web.Response(status=401, text="Invalid state token")
+            return web.Response(status=401, text="Invalid state token because of ValueError")
         except (KeyError, ClientError):
-            return web.Response(status=401, text="Failed to finish login")
+            return web.Response(status=401, text=f"Failed to finish login{ClientError}")
         resp = await client.query("viewer { login }")
         user = resp["viewer"]["login"]
         self.put(user_id, client.token)

--- a/github/commands.py
+++ b/github/commands.py
@@ -111,7 +111,6 @@ class Commands:
     @command.argument("flags", required=False, pass_raw=True)
     @authenticated(required=False)
     async def login(self, evt: MessageEvent, flags: str, client: Optional[GitHubClient]) -> None:
-        redirect_url = (self.bot.webapp_url / "auth").with_query({"user_id": evt.sender})
         flags = flags.lower()
         scopes = ["user:user", "public_repo", "admin:repo_hook"]
         if "--no-repo" in flags:

--- a/github/commands.py
+++ b/github/commands.py
@@ -120,8 +120,10 @@ class Commands:
             scopes.remove("admin:repo_hook")
         if "--private" in flags:
             scopes.append("repo")
+        # Pass user_id for state in Oauth
+        user_id = evt.sender
         login_url = str(self.bot.clients.get(evt.sender, create=True).get_login_url(
-            redirect_uri=redirect_url, scope=" ".join(scopes)))
+            user_id=user_id, scope=" ".join(scopes)))
         if client:
             username = await client.query("viewer { login }", path="viewer.login")
             await evt.reply(f"You're already logged in as @{username}, but you can "


### PR DESCRIPTION
The current implementation uses a trick where the redirect URL is passed with a parameter specifying the userID so on return, the specific userID can be extracted from the called URL again. This is against the spec of Oauths RFC and does currently work with Github, however while trying to reuse the code for interacting with the Wrike API it turned out to be problematic.

This is what I'm referring to:

```
Per-Request Customization

Often times a developer will think that they need to be able to use a different redirect URL on each authorization request, and will try to change the query string parameters per request. This is not the intended use of the redirect URL, and **should not be allowed by the authorization server**. **The server should reject any authorization requests with redirect URLs that are not an exact match of a registered URL.**

If a client wishes to include request-specific data in the redirect URL, it can instead use the “state” parameter to store data that will be included after the user is redirected. It can either encode the data in the state parameter itself, or use the state parameter as a session ID to store the state on the server.

```

Now as during the creation of the github oauth app, the redirect URL is specified *without* the UserID field, it should not work.

I edited the code to instead put the userID in the state field and extract it when returning back to maubot. 

I tried to make sure that the delimiter between the userID and the state would not run into any conflicts. The chosen "%" is not a viable character for userIDs in matrix (https://spec.matrix.org/v1.8/appendices/#user-identifiers) and also poses no problems with URLs.

As I'm working on my end with different APIs from Wrike, would it be possible for you to check if these commits work on Github as well or if you run into other issues?