### PR TITLE
Added avatar refresh

### DIFF
--- a/github/avatar_manager.py
+++ b/github/avatar_manager.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 import asyncio
+import time
 
 from sqlalchemy import Column, MetaData, Table, Text
 from sqlalchemy.engine.base import Engine
@@ -15,6 +16,8 @@ if TYPE_CHECKING:
 class AvatarManager:
     bot: "GitHubBot"
     _avatars: dict[str, ContentURI]
+    _etag: dict[str, Optional[str]]
+    _fetched_at: dict[str, int]
     _db: DBManager
     _lock: asyncio.Lock
 
@@ -23,26 +26,50 @@ class AvatarManager:
         self._db = bot.db
         self._lock = asyncio.Lock()
         self._avatars = {}
+        self._etag = {}
+        self._fetched_at = {}
 
     async def load_db(self) -> None:
-        self._avatars = {
-            avatar.url: ContentURI(avatar.mxc) for avatar in await self._db.get_avatars()
-        }
+        rows = await self._db.get_avatars()
+        self._avatars = {avatar.url: ContentURI(avatar.mxc) for avatar in rows}
+        self._etag = {avatar.url: avatar.etag for avatar in rows}
+        self._fetched_at = {avatar.url: int(avatar.fetched_at or 0) for avatar in rows}
 
     async def get_mxc(self, url: str) -> ContentURI:
-        try:
+        now = int(time.time())
+        # 5 min TTL
+        if url in self._avatars and (now - self._fetched_at.get(url, 0)) < 300:
             return self._avatars[url]
-        except KeyError:
-            pass
-        async with self.bot.http.get(url) as resp:
+
+        headers: dict[str, str] = {}
+        etag = self._etag.get(url)
+        if etag:
+            headers["If-None-Match"] = etag
+
+        async with self.bot.http.get(url, headers=headers) as resp:
+            if resp.status == 304 and url in self._avatars:
+                # Unchanged: bump fetched_at and persist
+                self._fetched_at[url] = now
+                await self._db.put_avatar(
+                    url,
+                    self._avatars[url],
+                    etag=self._etag.get(url),
+                    fetched_at=now,
+                )
+                return self._avatars[url]
+
             resp.raise_for_status()
             data = await resp.read()
+            new_etag = resp.headers.get("ETag")
+
         async with self._lock:
-            try:
+            # Race guard with same TTL inside the lock
+            if url in self._avatars and (now - self._fetched_at.get(url, 0)) < 300:
                 return self._avatars[url]
-            except KeyError:
-                pass
+
             mxc = await self.bot.client.upload_media(data)
             self._avatars[url] = mxc
-            await self._db.put_avatar(url, mxc)
-        return mxc
+            self._etag[url] = new_etag
+            self._fetched_at[url] = now
+            await self._db.put_avatar(url, mxc, etag=new_etag, fetched_at=now)
+            return mxc

--- a/github/avatar_manager.py
+++ b/github/avatar_manager.py
@@ -10,8 +10,8 @@ from .db import DBManager
 if TYPE_CHECKING:
     from .bot import GitHubBot
 
-_TTL = 300
-_DB_TOUCH_INTERVAL = 3600
+_TTL = 3600
+_DB_TOUCH_INTERVAL = 86400
 
 
 @dataclass

--- a/github/avatar_manager.py
+++ b/github/avatar_manager.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
+from dataclasses import dataclass
 import asyncio
 import time
-
-from sqlalchemy import Column, MetaData, Table, Text
-from sqlalchemy.engine.base import Engine
 
 from mautrix.types import ContentURI
 
@@ -12,64 +10,87 @@ from .db import DBManager
 if TYPE_CHECKING:
     from .bot import GitHubBot
 
+_TTL = 300
+_DB_TOUCH_INTERVAL = 3600
+
+
+@dataclass
+class _Entry:
+    mxc: ContentURI
+    etag: str | None
+    fetched_at_mono: float
+    db_fetched_at_wall: int
+
 
 class AvatarManager:
     bot: "GitHubBot"
-    _avatars: dict[str, ContentURI]
-    _etag: dict[str, Optional[str]]
-    _fetched_at: dict[str, int]
     _db: DBManager
-    _lock: asyncio.Lock
+    _entries: dict[str, _Entry]
+    _inflight: dict[str, asyncio.Task[ContentURI]]
 
     def __init__(self, bot: "GitHubBot") -> None:
         self.bot = bot
         self._db = bot.db
-        self._lock = asyncio.Lock()
-        self._avatars = {}
-        self._etag = {}
-        self._fetched_at = {}
+        self._entries = {}
+        self._inflight = {}
 
     async def load_db(self) -> None:
         rows = await self._db.get_avatars()
-        self._avatars = {avatar.url: ContentURI(avatar.mxc) for avatar in rows}
-        self._etag = {avatar.url: avatar.etag for avatar in rows}
-        self._fetched_at = {avatar.url: int(avatar.fetched_at or 0) for avatar in rows}
+        now_mono = time.monotonic()
+        now_wall = int(time.time())
+        entries: dict[str, _Entry] = {}
+        for avatar in rows:
+            db_fetched_at = int(avatar.fetched_at or 0)
+            # Map wall-clock fetched_at to monotonic so TTL survives restarts.
+            elapsed = max(0, now_wall - db_fetched_at) if db_fetched_at > 0 else _TTL + 1
+            entries[avatar.url] = _Entry(
+                mxc=ContentURI(avatar.mxc),
+                etag=avatar.etag,
+                fetched_at_mono=now_mono - elapsed,
+                db_fetched_at_wall=db_fetched_at,
+            )
+        self._entries = entries
 
     async def get_mxc(self, url: str) -> ContentURI:
-        now = int(time.time())
-        # 5 min TTL
-        if url in self._avatars and (now - self._fetched_at.get(url, 0)) < 300:
-            return self._avatars[url]
+        entry = self._entries.get(url)
+        if entry is not None and (time.monotonic() - entry.fetched_at_mono) < _TTL:
+            return entry.mxc
 
+        task = self._inflight.get(url)
+        if task is None:
+            task = asyncio.create_task(self._fetch(url))
+            self._inflight[url] = task
+            task.add_done_callback(lambda _t, u=url: self._inflight.pop(u, None))
+        return await task
+
+    async def _fetch(self, url: str) -> ContentURI:
+        entry = self._entries.get(url)
         headers: dict[str, str] = {}
-        etag = self._etag.get(url)
-        if etag:
-            headers["If-None-Match"] = etag
+        if entry is not None and entry.etag:
+            headers["If-None-Match"] = entry.etag
 
         async with self.bot.http.get(url, headers=headers) as resp:
-            if resp.status == 304 and url in self._avatars:
-                # Unchanged: bump fetched_at and persist
-                self._fetched_at[url] = now
-                await self._db.put_avatar(
-                    url,
-                    self._avatars[url],
-                    etag=self._etag.get(url),
-                    fetched_at=now,
-                )
-                return self._avatars[url]
+            if resp.status == 304 and entry is not None:
+                entry.fetched_at_mono = time.monotonic()
+                now_wall = int(time.time())
+                if now_wall - entry.db_fetched_at_wall >= _DB_TOUCH_INTERVAL:
+                    await self._db.put_avatar(
+                        url, entry.mxc, etag=entry.etag, fetched_at=now_wall,
+                    )
+                    entry.db_fetched_at_wall = now_wall
+                return entry.mxc
 
             resp.raise_for_status()
             data = await resp.read()
             new_etag = resp.headers.get("ETag")
 
-        async with self._lock:
-            # Race guard with same TTL inside the lock
-            if url in self._avatars and (now - self._fetched_at.get(url, 0)) < 300:
-                return self._avatars[url]
-
-            mxc = await self.bot.client.upload_media(data)
-            self._avatars[url] = mxc
-            self._etag[url] = new_etag
-            self._fetched_at[url] = now
-            await self._db.put_avatar(url, mxc, etag=new_etag, fetched_at=now)
-            return mxc
+        mxc = await self.bot.client.upload_media(data)
+        now_wall = int(time.time())
+        self._entries[url] = _Entry(
+            mxc=mxc,
+            etag=new_etag,
+            fetched_at_mono=time.monotonic(),
+            db_fetched_at_wall=now_wall,
+        )
+        await self._db.put_avatar(url, mxc, etag=new_etag, fetched_at=now_wall)
+        return mxc

--- a/github/db.py
+++ b/github/db.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from typing import Optional
 import hashlib
 import hmac
@@ -47,6 +48,8 @@ class Client:
 class Avatar:
     url: str
     mxc: ContentURI
+    etag: Optional[str] = None
+    fetched_at: int = 0
 
     @classmethod
     def from_row(cls, row: Record | None) -> Optional["Avatar"]:
@@ -54,9 +57,13 @@ class Avatar:
             return None
         url = row["url"]
         mxc = row["mxc"]
+        etag = row.get("etag")
+        fetched_at = int(row.get("fetched_at") or 0)
         return cls(
             url=url,
             mxc=mxc,
+            etag=etag,
+            fetched_at=fetched_at,
         )
 
 
@@ -145,17 +152,29 @@ class DBManager:
         )
 
     async def get_avatars(self) -> list[Avatar]:
-        rows = await self.db.fetch("SELECT url, mxc FROM avatar")
+        rows = await self.db.fetch("SELECT url, mxc, etag, fetched_at FROM avatar")
         return [Avatar.from_row(row) for row in rows]
 
-    async def put_avatar(self, url: str, mxc: ContentURI) -> None:
+    async def put_avatar(
+        self,
+        url: str,
+        mxc: ContentURI,
+        *,
+        etag: Optional[str] = None,
+        fetched_at: Optional[int] = None,
+    ) -> None:
         await self.db.execute(
             """
-            INSERT INTO avatar (url, mxc) VALUES ($1, $2)
-            ON CONFLICT (url) DO NOTHING
+            INSERT INTO avatar (url, mxc, etag, fetched_at) VALUES ($1, $2, $3, $4)
+            ON CONFLICT (url) DO UPDATE SET
+                mxc = excluded.mxc,
+                etag = excluded.etag,
+                fetched_at = excluded.fetched_at
             """,
             url,
             mxc,
+            etag,
+            fetched_at,
         )
 
     async def get_webhook_by_id(self, id: uuid.UUID) -> WebhookInfo | None:

--- a/github/migrations.py
+++ b/github/migrations.py
@@ -13,12 +13,13 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from mautrix.util.async_db import Connection, Scheme, UpgradeTable
 
 upgrade_table = UpgradeTable()
 
 
-@upgrade_table.register(description="Latest revision", upgrades_to=1)
+@upgrade_table.register(description="Initial schema", upgrades_to=1)
 async def upgrade_latest(conn: Connection, scheme: Scheme) -> None:
     needs_migration = False
     if await conn.table_exists("webhook"):
@@ -67,6 +68,13 @@ async def upgrade_latest(conn: Connection, scheme: Scheme) -> None:
 async def migrate_legacy_to_v1(conn: Connection) -> None:
     await conn.execute("INSERT INTO client (user_id, token) SELECT user_id, token FROM client_old")
     await conn.execute(
-        "INSERT INTO matrix_message (message_id, room_id, event_id) SELECT message_id, room_id, event_id FROM matrix_message_old"
+        "INSERT INTO matrix_message (message_id, room_id, event_id) "
+        "SELECT message_id, room_id, event_id FROM matrix_message_old"
     )
     await conn.execute("CREATE TABLE needs_post_migration(noop INTEGER PRIMARY KEY)")
+
+
+@upgrade_table.register(description="Add etag and fetched_at to avatar table", upgrades_to=2)
+async def upgrade_v2(conn: Connection) -> None:
+    await conn.execute("ALTER TABLE avatar ADD COLUMN etag TEXT")
+    await conn.execute("ALTER TABLE avatar ADD COLUMN fetched_at INTEGER")


### PR DESCRIPTION
Avatars refresh based on tracking eTags and last fetched time. >300 sec after eTag was last checked/fetched, the plugin will check headers only and check if etag has changed vs what is in the plugin db. If eTag has changed, a new avatar will be downloaded